### PR TITLE
Update runtime to 42

### DIFF
--- a/io.github.seadve.Mousai.json
+++ b/io.github.seadve.Mousai.json
@@ -59,46 +59,6 @@
       ]
     },
     {
-      "name": "libsass",
-      "cleanup": [
-        "*"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/sass/libsass/archive/3.6.5.tar.gz",
-          "sha256": "89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582"
-        },
-        {
-          "type": "script",
-          "dest-filename": "autogen.sh",
-          "commands": [
-            "autoreconf -si"
-          ]
-        }
-      ]
-    },
-    {
-      "name": "sassc",
-      "cleanup": [
-        "*"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/sass/sassc/archive/3.6.2.tar.gz",
-          "sha256": "608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03"
-        },
-        {
-          "type": "script",
-          "dest-filename": "autogen.sh",
-          "commands": [
-            "autoreconf -si"
-          ]
-        }
-      ]
-    },
-    {
       "name": "mousai",
       "builddir": true,
       "buildsystem": "meson",

--- a/io.github.seadve.Mousai.json
+++ b/io.github.seadve.Mousai.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.seadve.Mousai",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "40",
+  "runtime-version": "42",
   "sdk": "org.gnome.Sdk",
   "command": "mousai",
   "finish-args": [
@@ -66,8 +66,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/sass/libsass/archive/3.6.4.tar.gz",
-          "sha256": "f9484d9a6df60576e791566eab2f757a97fd414fce01dd41fc0a693ea5db2889"
+          "url": "https://github.com/sass/libsass/archive/3.6.5.tar.gz",
+          "sha256": "89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582"
         },
         {
           "type": "script",
@@ -86,8 +86,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/sass/sassc/archive/3.6.1.tar.gz",
-          "sha256": "8cee391c49a102b4464f86fc40c4ceac3a2ada52a89c4c933d8348e3e4542a60"
+          "url": "https://github.com/sass/sassc/archive/3.6.2.tar.gz",
+          "sha256": "608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03"
         },
         {
           "type": "script",
@@ -95,24 +95,6 @@
           "commands": [
             "autoreconf -si"
           ]
-        }
-      ]
-    },
-    {
-      "name": "libadwaita",
-      "buildsystem": "meson",
-      "config-opts": [
-        "-Dgtk_doc=false",
-        "-Dtests=false",
-        "-Dexamples=false",
-        "-Dvapi=false",
-        "-Dglade_catalog=disabled"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
-          "commit": "8014b17994c1545fad7f5594f1dcdbf0bfc16293"
         }
       ]
     },


### PR DESCRIPTION
Also removed libadwaita and its build dependencies since that is now included in the runtime.

Currently runtime 40 is used, which has been marked end-of-life since 21 March 2022.