### PR TITLE
chore: bump runtime to gnome 48

### DIFF
--- a/io.github.seadve.Mousai.json
+++ b/io.github.seadve.Mousai.json
@@ -1,7 +1,7 @@
 {
     "id": "io.github.seadve.Mousai",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
can be tested with `flatpak run --runtime-version=48 io.github.seadve.Mousai`