### PR TITLE
bump runtime to 50

### DIFF
--- a/io.github.seadve.Mousai.json
+++ b/io.github.seadve.Mousai.json
@@ -1,7 +1,7 @@
 {
     "id": "io.github.seadve.Mousai",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Thank you for creating this nice app!

This PR bumps the GNOME runtime to 50, as 48 is EOL